### PR TITLE
Fix crash with 2.3.8

### DIFF
--- a/src/DCCAnalyzerResults.cpp
+++ b/src/DCCAnalyzerResults.cpp
@@ -406,6 +406,7 @@ void DCCAnalyzerResults::GenerateFrameTabularText(U64 frame_index, DisplayBase d
         snprintf(result_str, sizeof(result_str), "Checksum: %#02llx", frame.mData1);
         break;
     default:
+		snprintf(result_str, sizeof(result_str), "Invalid Frame Type: %u", ft);
         break;
     }
     AddTabularText(result_str);


### PR DESCRIPTION
GenerateFrameTabularText would return uninitialized data as a string if the frame type was not a valid number. Now it always returns a valid string.