### PR TITLE
New release for RailCom Cutout Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DCCAnalyzer v0.0.2
+# DCCAnalyzer v0.0.3
 
 This repository is for maintaining the software associated with decoding DCC packets using a logic analyzer.
 


### PR DESCRIPTION
First version that supports RailCom Cutout on both phases of DCC and tested using a Lenz LZV200 command station.